### PR TITLE
feat(ux): implement help overlay (TODO 2) with keyboard toggle and ARIA

### DIFF
--- a/hack/radio_iss/css/styles.css
+++ b/hack/radio_iss/css/styles.css
@@ -193,3 +193,86 @@ body {
   background: rgba(255,255,255,0.3);
 }
 
+/* Help overlay */
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 20;
+}
+
+.help-overlay[aria-hidden="false"] {
+  display: block;
+}
+
+.help-overlay-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.help-overlay-dialog {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.92);
+  color: #fff;
+  border-radius: 14px;
+  padding: 18px 18px 14px;
+  width: min(92vw, 520px);
+  box-shadow: 0 8px 40px rgba(0,0,0,0.6);
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, sans-serif;
+}
+
+.help-overlay-title {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+
+.help-overlay-list {
+  margin: 0 0 10px;
+  padding-left: 18px;
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.help-overlay-list kbd {
+  background: rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-bottom-width: 2px;
+  border-radius: 6px;
+  padding: 2px 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+}
+
+.help-overlay-hint {
+  margin: 0;
+  opacity: 0.8;
+  font-size: 12px;
+}
+
+.help-overlay-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.3);
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  cursor: pointer;
+}
+
+@media (width <= 768px) {
+  .help-overlay-dialog {
+    padding: 16px 14px 12px;
+  }
+  .help-overlay-title {font-size: 16px;}
+  .help-overlay-list {font-size: 13px;}
+  .help-overlay-hint {font-size: 12px;}
+}
+

--- a/hack/radio_iss/index.html
+++ b/hack/radio_iss/index.html
@@ -32,7 +32,7 @@
   <meta name="twitter:image:alt" content="Radio ISS visualization with pulsating ISS particle and radio UI">
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js"></script>
-  <link rel="stylesheet" href="css/styles.css?v=1754855385">
+  <link rel="stylesheet" href="css/styles.css?v=1754858683">
   <!-- Version: commit 222af77 - Ultra compact mobile UI -->
 </head>
 <body>
@@ -47,10 +47,27 @@
   
   <!-- Fullscreen button positioned in bottom right -->
   <button id="fullscreen-btn" type="button" class="fullscreen-btn-floating" aria-pressed="false">⛶</button>
-  <script src="js/particles.js?v=1754855385"></script>
-  <script src="js/radio.js?v=1754855385"></script>
-  <script src="js/geography.js?v=1754855385"></script>
-  <script src="js/main.js?v=1754855385"></script>
+
+  <!-- Help overlay (shortcut '?') -->
+  <div id="help-overlay" class="help-overlay" aria-hidden="true">
+    <div class="help-overlay-backdrop" data-overlay-dismiss></div>
+    <div class="help-overlay-dialog" role="dialog" aria-modal="true" aria-labelledby="help-title">
+      <button class="help-overlay-close" type="button" aria-label="Close help" data-overlay-dismiss>×</button>
+      <h2 id="help-title" class="help-overlay-title">Keyboard & Touch Shortcuts</h2>
+      <ul class="help-overlay-list" aria-describedby="help-desc">
+        <li><kbd>P</kbd> Play/Pause <span class="help-mobile">(mobile: tap ▶)</span></li>
+        <li><kbd>F</kbd> Fullscreen <span class="help-mobile">(mobile: tap ⛶)</span></li>
+        <li><kbd>M</kbd> Toggle continent outlines</li>
+        <li><kbd>?</kbd> Open help overlay</li>
+        <li><kbd>Esc</kbd> Close help</li>
+      </ul>
+      <p id="help-desc" class="help-overlay-hint">Click outside or press Esc to dismiss.</p>
+    </div>
+  </div>
+  <script src="js/particles.js?v=1754858683"></script>
+  <script src="js/radio.js?v=1754858683"></script>
+  <script src="js/geography.js?v=1754858683"></script>
+  <script src="js/main.js?v=1754858683"></script>
 </body>
 </html>
 

--- a/hack/radio_iss/js/main.js
+++ b/hack/radio_iss/js/main.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-/* global setup, draw, windowResized, keyPressed, createCanvas, background, fill, noStroke, circle, text, textSize, key, keyIsPressed, width, height, random, constrain, lerp, dist, cos, sin, TWO_PI, rect, navigator */
+/* global setup, draw, windowResized, keyPressed, createCanvas, background, fill, noStroke, circle, text, textSize, key, keyIsPressed, keyCode, width, height, random, constrain, lerp, dist, cos, sin, TWO_PI, rect, navigator */
 
 // Main application for ISS Radio
 // Global variables
@@ -19,6 +19,8 @@ let particleGeoData = []; // Store original geographic data for particles
 let radioManager;
 let geographyManager;
 let showContinentOutlines = false; // Toggle for continent outline visualization
+let helpOverlayEl; // Help overlay element
+let helpOverlayVisible = false;
 
 function setup() {
   // iOS Safari viewport height fix
@@ -42,6 +44,13 @@ function setup() {
 
   // Initialize radio UI
   radioManager.init();
+
+  // Help overlay wiring
+  helpOverlayEl = document.getElementById('help-overlay');
+  const overlayDismissEls = document.querySelectorAll('[data-overlay-dismiss]');
+  overlayDismissEls.forEach((el) => {
+    el.addEventListener('click', () => hideHelpOverlay());
+  });
 
   // Set up fullscreen event listeners for canvas resizing
   document.addEventListener('fullscreenchange', () => {
@@ -163,6 +172,30 @@ function keyPressed() {
       radioManager.togglePlayback();
     }
   }
+  // Toggle help overlay on '?' key
+  if (key === '?') {
+    if (helpOverlayVisible) {
+      hideHelpOverlay();
+    } else {
+      showHelpOverlay();
+    }
+  }
+  // Close help with Esc
+  if (keyCode === 27 && helpOverlayVisible) {
+    hideHelpOverlay();
+  }
+}
+
+function showHelpOverlay() {
+  if (!helpOverlayEl) {return;}
+  helpOverlayEl.setAttribute('aria-hidden', 'false');
+  helpOverlayVisible = true;
+}
+
+function hideHelpOverlay() {
+  if (!helpOverlayEl) {return;}
+  helpOverlayEl.setAttribute('aria-hidden', 'true');
+  helpOverlayVisible = false;
 }
 
 function draw() {

--- a/hack/radio_iss/ux.md
+++ b/hack/radio_iss/ux.md
@@ -6,7 +6,7 @@ Below is a numbered, actionable list of UX improvements. Each item is scoped to 
    - Brief, auto-fading tooltip on first load: “Press P to play/pause, F fullscreen, M outlines. Tap ⛶ on mobile.”
    - Auto-hide after 6–8s or on any interaction.
 
-2. [ ] Help overlay (shortcut `?`)
+2. [x] Help overlay (shortcut `?`)
    - Press `?` to open a lightweight overlay listing shortcuts and toggles; tap/click outside or press `Esc` to dismiss.
    - Include: P play/pause, F fullscreen, M outlines, ? help; show mobile equivalents.
 


### PR DESCRIPTION
Adds a lightweight help overlay opened by '?' and dismissed by Esc/click-outside. Includes keyboard and mobile hints, styles, and wiring in main.js. Updates cache-busting and checks off item 2 in ux.md.