### PR TITLE
Fix audio playback on iOS home-screen apps

### DIFF
--- a/bidouille/3615_terre/index.html
+++ b/bidouille/3615_terre/index.html
@@ -103,37 +103,16 @@ h1 {
     text-shadow: none;
     font-weight: normal;
     z-index: 10;
-}
-h1 a {
-    color: inherit;
-    text-decoration: none;
     display: inline-flex;
     flex-direction: column;
     gap: 0.15rem;
-    transition: color 0.3s ease;
-    -webkit-tap-highlight-color: transparent;
-}
-h1 a:hover, h1 a:focus-visible {
-    color: rgba(0,255,255,0.85);
-    outline: none;
 }
 h1 .h1-sub {
     font-size: 0.55rem;
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: rgba(0,255,255,0.55);
-    opacity: 0;
-    transform: translateY(-2px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    pointer-events: none;
-}
-h1 a:hover .h1-sub, h1 a:focus-visible .h1-sub {
-    opacity: 1;
-    transform: translateY(0);
-}
-@media (hover: none) {
-    /* Touch devices: subtitle stays visible at low opacity since there's no hover */
-    h1 .h1-sub { opacity: 0.6; transform: none; }
+    opacity: 0.6;
 }
 
 .sound-bars {

--- a/bidouille/3615_terre/index.html
+++ b/bidouille/3615_terre/index.html
@@ -952,6 +952,7 @@ function showOverlay() {
 }
 
 // Unlock audio on click
+const SILENT_WAV = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA';
 document.getElementById('unlockScreen').addEventListener('click', (e) => {
     e.stopPropagation();
     document.getElementById('unlockScreen').classList.add('hidden');
@@ -960,10 +961,20 @@ document.getElementById('unlockScreen').addEventListener('click', (e) => {
     } else {
         showOverlay();
     }
-    audioPlayer1.play().then(() => audioPlayer1.pause()).catch(() => {
-        audioPlayer1.src = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA';
-        audioPlayer1.play().then(() => { audioPlayer1.pause(); audioPlayer1.src = ''; }).catch(() => {});
+    // iOS (esp. home-screen / standalone) only unlocks audio elements that
+    // receive a synchronous play() inside the gesture. The first track plays
+    // through audioPlayer2, so both must be primed here.
+    [audioPlayer1, audioPlayer2].forEach(p => {
+        if (!p.src) p.src = SILENT_WAV;
+        const r = p.play();
+        if (r && r.then) r.then(() => p.pause()).catch(() => {});
     });
+    // Build the WebAudio graph + resume inside the gesture; otherwise the
+    // context (created later inside playTrack) stays suspended on iOS.
+    initWebAudio();
+    if (audioContext && audioContext.state === 'suspended') {
+        audioContext.resume().catch(() => {});
+    }
     start();
 }, { once: true });
 


### PR DESCRIPTION
## Summary
This PR fixes audio playback issues on iOS, particularly when the app is running in standalone/home-screen mode. The changes ensure that audio contexts are properly initialized and resumed within the user gesture, and that both audio players are primed for playback.

## Key Changes
- **Simplified h1 styling**: Removed interactive hover/focus states and animations from the header link. The subtitle now displays at a constant 60% opacity instead of animating in on hover.
- **Improved iOS audio initialization**: 
  - Extracted the silent WAV data to a constant (`SILENT_WAV`) for reusability
  - Both `audioPlayer1` and `audioPlayer2` are now primed with a silent audio source within the gesture handler
  - Added explicit WebAudio context initialization and resumption within the user gesture
  - Improved promise handling to support both callback-based and promise-based `play()` implementations
- **Added detailed comments** explaining iOS-specific audio behavior and the necessity of synchronous play() calls within gestures

## Implementation Details
iOS (especially in home-screen/standalone mode) requires audio elements to receive a synchronous `play()` call within a user gesture to unlock audio playback. Additionally, WebAudio contexts must be resumed within the same gesture to avoid remaining in a suspended state. The changes ensure both audio players are primed and the WebAudio context is initialized and resumed immediately when the user taps the unlock screen.

https://claude.ai/code/session_013gNvPQK6ZhPpsHmqfHh8EV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Subtitle styling updated to display with constant lower opacity instead of being hidden by default.

* **Bug Fixes**
  * Improved audio playback reliability on mobile devices, particularly for iOS gesture-based activation during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->