### PR TITLE
fix(3615_terre): don't leak guessed location in loading status

### DIFF
--- a/bidouille/3615_terre/index.html
+++ b/bidouille/3615_terre/index.html
@@ -757,14 +757,12 @@ async function findAndPlayNearestSound() {
             const controller = new AbortController();
             soundFetchController = controller;
 
-            setStatus('Localisation du son…');
             const locationInfo = await geocodeLocation(nearest.lat, nearest.lng, controller.signal);
             if (controller.signal.aborted) return;
             currentLocationInfo = locationInfo;
             updateSoundInfo();
 
-            const cityLabel = (locationInfo && (locationInfo.city || locationInfo.country)) || nearest.locationName || 'inconnu';
-            setStatus(`Réception · ${cityLabel}…`);
+            setStatus('Réception en cours…');
             const track = { identifier: nearest.identifier, title: nearest.title, artist: nearest.creator };
             await playTrack(track, controller.signal);
         } else {


### PR DESCRIPTION
## Summary

The point of the radio is to guess where the ISS is from the ambient sound — so the loading status must not name the city we're tuning to. The previous PR introduced `Réception · <ville>…` which was a spoiler.

- Drop the city-named status (`Réception · <ville>…`) and the hint phrase (`Localisation du son…`).
- Collapse to a single neutral `Réception en cours…` once geocode + track URL are ready.
- The `H`-key reveal still works for anyone who wants to peek at the answer.

## Test plan

- [ ] On mobile, tap unlock → status shows `CONNEXION À LA STATION SPATIALE…`, then `RÉCEPTION EN COURS…`, then disappears once audio plays. No city name appears.
- [ ] Press `H` on desktop: location info still toggles correctly under the visualizer.

https://claude.ai/code/session_013gNvPQK6ZhPpsHmqfHh8EV

---
_Generated by [Claude Code](https://claude.ai/code/session_013gNvPQK6ZhPpsHmqfHh8EV)_