### PR TITLE
fix(radio_iss): bump vite to 7.3.6 to clear Dependabot alerts

### DIFF
--- a/hack/radio_iss/package-lock.json
+++ b/hack/radio_iss/package-lock.json
@@ -4584,13 +4584,13 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",


### PR DESCRIPTION
## What

Bumps the transitive `vite` dependency in `hack/radio_iss` from `7.3.2` → `7.3.6`, clearing the two open Dependabot alerts:

| Severity | Advisory | Issue |
|----------|----------|-------|
| High | GHSA-fx2h-pf6j-xcff | `server.fs.deny` bypass on Windows alternate paths |
| Moderate | GHSA-v6wh-96g9-6wx3 | NTLMv2 hash disclosure via UNC path (launch-editor) |

## Impact

Both are **dev-server-only, Windows-only** advisories. This repo deploys as static files via GitHub Pages, so vite never runs in production — no live exposure. This keeps tooling current and clears the alerts.

## Verification

- `vite` resolves to `7.3.6` (≥ 7.3.5 patched)
- Pre-commit hook ran the test suite: **20/20 passing**
- Only `package-lock.json` changed (4 insertions, 4 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)