### PR TITLE
feat(spatial_audio): warmer pad with locator blips, orbit varies distance

### DIFF
--- a/bidouille/spatial_audio/index.html
+++ b/bidouille/spatial_audio/index.html
@@ -215,52 +215,69 @@
       coneOuterGain: 0,
     });
 
-    // ---- ambient loop: two detuned saw pads + a slow shimmer bell ----------
+    // ---- ambient loop: warm sine/triangle pads + soft bells + locator blips --
     const master = ac.createGain();
     master.gain.value = 0.0;
 
-    // Pad: two oscillators through a slow lowpass, gentle vibrato.
-    const padGain = ac.createGain(); padGain.gain.value = 0.16;
+    // Pad: a warm C-major triad through a gentle lowpass, soft chorus.
+    const padGain = ac.createGain(); padGain.gain.value = 0.18;
     const lp = ac.createBiquadFilter();
-    lp.type = "lowpass"; lp.frequency.value = 900; lp.Q.value = 0.7;
+    lp.type = "lowpass"; lp.frequency.value = 1200; lp.Q.value = 0.5;
 
-    const baseFreqs = [110, 110 * 1.5, 110 * 2.0]; // A2, E3, A3 — open fifth/octave
+    const baseFreqs = [130.81, 164.81, 196.00]; // C3 · E3 · G3 — warm major triad
+    const oscTypes = ["sine", "triangle", "sine"];
     const oscs = [];
     baseFreqs.forEach((f, i) => {
       const o = ac.createOscillator();
-      o.type = i === 0 ? "sawtooth" : "triangle";
+      o.type = oscTypes[i];
       o.frequency.value = f;
-      o.detune.value = (i - 1) * 6;     // slight spread
+      o.detune.value = (i - 1) * 4;     // slight spread for warmth
       const g = ac.createGain();
-      g.gain.value = i === 0 ? 0.5 : 0.3;
+      g.gain.value = i === 0 ? 0.4 : 0.3;
       o.connect(g).connect(lp);
       o.start();
       oscs.push(o);
     });
     lp.connect(padGain).connect(panner);
 
-    // Shimmer: a slow LFO opens the filter to "breathe".
+    // Shimmer: a slow, gentle LFO breathes the filter (less sweep than before).
     const lfo = ac.createOscillator();
-    lfo.frequency.value = 0.06;
-    const lfoGain = ac.createGain(); lfoGain.gain.value = 450;
+    lfo.frequency.value = 0.05;
+    const lfoGain = ac.createGain(); lfoGain.gain.value = 180;
     lfo.connect(lfoGain).connect(lp.frequency);
     lfo.start();
 
-    // Bell shimmer: periodic soft pings drift on top, panned with the source.
+    // Bells: soft, rare chimes on chord tones drift on top, panned with source.
     function ping() {
       const now = ac.currentTime;
       const o = ac.createOscillator();
       const g = ac.createGain();
-      const notes = [880, 1108, 1320, 1760];
+      const notes = [523.25, 659.25, 784.00]; // C5 · E5 · G5
       o.type = "sine";
       o.frequency.value = notes[(Math.random() * notes.length) | 0];
       g.gain.setValueAtTime(0, now);
-      g.gain.linearRampToValueAtTime(0.12, now + 0.02);
-      g.gain.exponentialRampToValueAtTime(0.0008, now + 2.6);
+      g.gain.linearRampToValueAtTime(0.08, now + 0.03);
+      g.gain.exponentialRampToValueAtTime(0.0006, now + 3.4);
       o.connect(g).connect(panner);
-      o.start(now); o.stop(now + 2.7);
+      o.start(now); o.stop(now + 3.5);
     }
-    const bellTimer = setInterval(() => { if (!muted) ping(); }, 3400);
+    const bellTimer = setInterval(() => { if (!muted) ping(); }, 5200);
+
+    // Locator blips: short, sharp transients make the source position easy to
+    // pinpoint by ear — fast onsets are the strongest HRTF localization cue.
+    function blip() {
+      const now = ac.currentTime;
+      const o = ac.createOscillator();
+      const g = ac.createGain();
+      o.type = "triangle";
+      o.frequency.value = 660;
+      g.gain.setValueAtTime(0, now);
+      g.gain.linearRampToValueAtTime(0.16, now + 0.005);   // sharp attack = locatable
+      g.gain.exponentialRampToValueAtTime(0.0006, now + 0.22);
+      o.connect(g).connect(panner);
+      o.start(now); o.stop(now + 0.26);
+    }
+    const blipTimer = setInterval(() => { if (!muted) blip(); }, 1500);
 
     panner.connect(master).connect(ac.destination);
 
@@ -574,8 +591,9 @@
     t += 1 / 60;
 
     if (autoOrbit) {
-      const r = MAX_R() * 0.78;
       const a = t * 0.5;
+      // radius drifts in and out on a slower cycle so distance changes too
+      const r = MAX_R() * (0.65 + 0.30 * Math.sin(t * 0.27));  // ~0.35–0.95 of max
       sx = cx + Math.cos(a) * r;
       sy = cy + Math.sin(a) * r * 0.62;   // ellipse = perspective
     }


### PR DESCRIPTION
Follow-up to #55 — this commit was pushed after #55 had already merged, so it never reached `main`.

## Summary
- **Warmer pad**: C-major triad on sine/triangle oscillators (no saw), gentler lowpass, slower filter breathing, softer/rarer bells on chord tones.
- **Locator blips**: short, sharp transients panned with the source so its 3D position is easy to pinpoint by ear (fast onsets are the strongest HRTF localization cue).
- **Auto-orbit varies distance**: the source radius now drifts in/out on a slower, non-harmonic cycle (~0.35–0.95 of max range), not just azimuth.

## Test plan
- [x] JS parses (`node --check`)
- [ ] Manual: Begin → toggle Auto-orbit → confirm the source moves nearer/farther and is easy to locate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new “locator” audio blips to make spatial cues more noticeable.
  * The ambient soundscape now uses a warmer tonal mix with smoother pads and updated shimmer accents.
  * Automatic orbiting now varies distance over time for a more dynamic motion feel.

* **Bug Fixes**
  * Improved audio timing and envelope behavior for clearer, more natural sound transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->